### PR TITLE
Add universe json scripts

### DIFF
--- a/universe/config.json
+++ b/universe/config.json
@@ -1,0 +1,158 @@
+{
+  "properties": {
+    "calico": {
+      "description": "Calico specific configuration properties.",
+      "properties": {
+        "framework-name": {
+          "type": "string",
+          "description": "The name of the framework.",
+          "default": "calico"
+        },
+        "allow-docker-update": {
+          "type": "boolean",
+          "description": "Whether the Calico framework is allowed to reconfigure and restart Docker on the Mesos Agent to install Docker with multi-host networking.  Note that during restart, the agent will not be available, and tasks running on the agent will be lost.",
+          "default": true
+        },
+        "max-concurrent-restarts": {
+          "type": "integer",
+          "description": "The maximum number of Agent or Docker restarts that are allowed to be scheduled concurrently by the Calico framework.",
+          "default": 1
+        },
+        "zk": {
+          "default": "zk://master.mesos:2181/calico",
+          "description": "The URL of Zookeeper to be used to persist Calico framework data. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/calico, including the trailing path.",
+          "type": "string"
+        },
+        "cpu-limit-framework": {
+          "default": 0.2,
+          "description": "The CPU shares for the Calico framework.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit-framework": {
+          "default": 512,
+          "description": "Memory limit (MB) for the Calico framework.",
+          "minimum": 32,
+          "type": "integer"
+        },
+        "cpu-limit-install": {
+          "default": 0.2,
+          "description": "The CPU shares for each install task instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit-install": {
+          "default": 512,
+          "description": "Memory limit (MB) for each install task instance.",
+          "minimum": 32,
+          "type": "integer"
+        },
+        "cpu-limit-etcd-proxy": {
+          "default": 0.1,
+          "description": "The CPU shares for each etcd proxy instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit-etcd-proxy": {
+          "default": 128,
+          "description": "Memory limit (MB) for each etcd proxy instance.",
+          "minimum": 32,
+          "type": "integer"
+        },
+        "cpu-limit-node": {
+          "default": 0.2,
+          "description": "The CPU shares for each Calico node instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit-node": {
+          "default": 256,
+          "description": "Memory limit (MB) for each Calico node instance.",
+          "minimum": 32,
+          "type": "integer"
+        },
+        "cpu-limit-libnetwork": {
+          "default": 0.2,
+          "description": "The CPU shares for each Calico Docker Network driver instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit-libnetwork": {
+          "default": 256,
+          "description": "Memory limit (MB) for each Calico Docker Network driver instance.",
+          "minimum": 32,
+          "type": "integer"
+        },
+        "status-dns": {
+          "default": "calico.marathon.mesos",
+          "description": "The DNS name used to resolve the Calico status web page.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "framework-name",
+        "allow-docker-update",
+        "max-concurrent-restarts",
+        "zk",
+        "cpu-limit-framework",
+        "mem-limit-framework",
+        "cpu-limit-install",
+        "mem-limit-install",
+        "cpu-limit-etcd-proxy",
+        "mem-limit-etcd-proxy",
+        "cpu-limit-node",
+        "mem-limit-node",
+        "cpu-limit-libnetwork",
+        "mem-limit-libnetwork",
+        "status-dns"
+      ],
+      "type": "object"
+    },
+    "etcd": {
+      "description": "etcd specific configuration properties",
+      "properties": {
+        "etcd-discovery-url": {
+          "default": "etcd.mesos",
+          "description": "The etcd service discovery URL used to determine the addresses of the full etcd cluster.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "etcd-discovery-url"
+      ],
+      "type": "object"
+    },
+    "mesos": {
+      "description": "Mesos specific configuration properties",
+      "properties": {
+        "master": {
+          "default": "zk://master.mesos:2181/mesos",
+          "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
+          "type": "string"
+        },
+        "cni-plugins-dir": {
+          "default": "/opt/mesos/cni/bin/",
+          "description": "Location of CNI plugins on the Agent.",
+          "type": "string"
+        },
+        "cni-config-dir": {
+          "default": "/opt/mesos/cni/conf/",
+          "description": "Location of CNI configs.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "master",
+        "cni-plugins-dir",
+        "cni-config-dir"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "calico",
+    "etcd",
+    "mesos"
+  ],
+  "type": "object"
+}

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -1,0 +1,55 @@
+{
+  "id": "{{calico.framework-name}}",
+  "container": {
+    "type": "DOCKER",
+    "network": "HOST",
+    "docker": {
+      "image": "{{resource.assets.container.docker.calico-dcos}}",
+      "network": "HOST",
+      "forcePullImage": true
+    }
+  },
+  "args": [],
+  "cpus": {{calico.cpu-limit-framework}},
+  "mem": {{calico.mem-limit-framework}},
+  "instances": 1,
+  "env": {
+    "CALICO_CALICOCTL_URL": "{{resource.assets.uris.calicoctl}}",
+    "CALICO_NODE_IMG": "{{resource.assets.container.docker.calico-node}}",
+    "CALICO_LIBNETWORK_IMG": "{{resource.assets.container.docker.calico-libnetwork}}",
+    {{#calico.allow-docker-update}}"CALICO_ALLOW_DOCKER_UPDATE": "true",{{/calico.allow-docker-update}}
+    "CALICO_MAX_CONCURRENT_RESTARTS": "{{calico.max-concurrent-restarts}}",
+    "CALICO_ZK": "{{calico.zk}}",
+    "CALICO_CPU_LIMIT_INSTALL": "{{calico.cpu-limit-install}}",
+    "CALICO_MEM_LIMIT_INSTALL": "{{calico.mem-limit-install}}",
+    "CALICO_CPU_LIMIT_ETCD_PROXY": "{{calico.cpu-limit-etcd-proxy}}",
+    "CALICO_MEM_LIMIT_ETCD_PROXY": "{{calico.mem-limit-etcd-proxy}}",
+    "CALICO_CPU_LIMIT_NODE": "{{calico.cpu-limit-node}}",
+    "CALICO_MEM_LIMIT_NODE": "{{calico.mem-limit-node}}",
+    "CALICO_CPU_LIMIT_LIBNETWORK": "{{calico.cpu-limit-libnetwork}}",
+    "CALICO_MEM_LIMIT_LIBNETWORK": "{{calico.mem-limit-libnetwork}}",
+    "CALICO_STATUS_DNS": "{{calico.status-dns}}",
+    "CALICO_INSTALLER_URL": "{{resource.assets.uris.calico-installer}}",
+    "ETCD_SRV": "{{etcd.etcd-discovery-url}}",
+    "ETCD_BINARY_URL": "{{resource.assets.uris.etcd}}",
+    "MESOS_MASTER": "{{mesos.master}}",
+    "MESOS_CNI_PLUGINS_DIR": "{{mesos.cni-plugins-dir}}",
+    "MESOS_CNI_CONFIG_DIR": "{{mesos.cni-config-dir}}",
+    "CALICO_CNI_BINARY_URL": "{{resource.assets.uris.calico-cni}}"
+  },
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{calico.framework-name}}"
+  },
+  "requirePorts":true,
+  "ports": [
+    0
+  ],
+  "healthChecks": [{
+    "protocol": "HTTP",
+    "path": "/health",
+    "portIndex": 0,
+    "gracePeriodSeconds": 60,
+    "intervalSeconds": 30,
+    "maxConsecutiveFailures": 0
+  }]
+}

--- a/universe/package.json
+++ b/universe/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "calico",
+  "version": "0.2.0",
+  "tags": ["calico", "networking", "ip-per-container", "ip-per-task", "policy"],
+  "description": "Calico networking for DCOS.  Calico provides IP-per-task functionality with rich policy.  This framework optionally installs Docker multi-host networking (required for Calico with the Docker containerizer) and Agent network hooks with netmodules (required for Calico with Unified tasks).  Both installations will cause temporary restarts of an Agent causing transient task loss.  The number of agents restarted at the same time is configurable and defaults to a single concurrent restart.  At the moment, only a limited set of DCOS versions and OSes are supported - check the documentation for details.  The framework will still run on unsupported versions, in which case the Agent network hooks will not be installed and Calico networking will only be available with the Docker containerizer.",
+  "scm": "https://github.com/projectcalico/calico-containers.git",
+  "website": "https://projectcalico.org",
+  "preInstallNotes": "Before installing Calico, ensure the DCOS etcd package is installed. Note: this scheduler makes permament changes to all Agents in the cluster. Calico Networking for DCOS is currently in alpha.",
+  "postInstallNotes": "Calico services are now running on your cluster. Follow the Calico DCOS guide available at https://github.com/projectcalico/calico-containers/blob/master/docs/mesos/DCOS.md",
+  "maintainer": "rob@projectcalico.org",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/projectcalico/calico-containers/master/LICENSE"
+    }
+  ],
+  "framework": true
+}

--- a/universe/resource.json
+++ b/universe/resource.json
@@ -1,0 +1,23 @@
+{
+  "images": {
+    "icon-small": "http://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-48-48.png",
+    "icon-medium": "http://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-96-96.png",
+    "icon-large": "http://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-256-256.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "calico-dcos": "djosborne/calico-dcos:v0.2.0",
+        "calico-node": "calico/node:v0.20.0",
+        "calico-libnetwork": "calico/node-libnetwork:v0.8.0"
+      }
+    },
+    "uris": {
+      "etcd": "https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz",
+      "calicoctl": "https://github.com/projectcalico/calico-containers/releases/download/v0.20.0/calicoctl",
+      "calico-cni": "https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico",
+      "calico-installer": "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.5/installer",
+      "calico.conf": "#"
+    }
+  }
+}


### PR DESCRIPTION
In an effort to keep better track the Universe scripts for calico-dcos, I am opening this PR to add them to this repo. I considered forking Universe, or creating a universe repository which only hosts the Calico package, but I do not want it to seem like the projectcalico github org is maintaining a universe, and ultimately decided that keeping them in this repository is simple enough for our needs.

Adding these scripts here should make it easier to collaborate on the Universe config changes necessary for the corresponding calico-dcos changes.