### PR TITLE
Bugfixes for Calico-CNI for DC/OS

### DIFF
--- a/framework/config.py
+++ b/framework/config.py
@@ -41,6 +41,7 @@ class Config(object):
 
         self.installer_url = self.getenv("CALICO_INSTALLER_URL")
         self.calico_cni_binary_url = self.getenv("CALICO_CNI_BINARY_URL")
+        self.calico_cni_ipam_binary_url = self.getenv("CALICO_CNI_IPAM_BINARY_URL")
 
         self.etcd_binary_url = self.getenv("ETCD_BINARY_URL")
         self.etcd_discovery = self.getenv("ETCD_SRV")

--- a/framework/config.py
+++ b/framework/config.py
@@ -23,7 +23,6 @@ _log = logging.getLogger(__name__)
 class Config(object):
     def __init__(self):
         self._missing = []
-        self.calicoctl_url = self.getenv("CALICO_CALICOCTL_URL")
         self.node_img = self.getenv("CALICO_NODE_IMG")
         self.libnetwork_img = self.getenv("CALICO_LIBNETWORK_IMG")
         self.allow_docker_update = bool(self.getenv("CALICO_ALLOW_DOCKER_UPDATE", can_omit=True))

--- a/framework/tasks.py
+++ b/framework/tasks.py
@@ -268,22 +268,17 @@ class TaskInstallCalicoCNI(Task):
     """
     hash = 0
     persistent = False
-    restarts = False
+    restarts = True
     cpus = config.cpu_limit_install
     mem = config.mem_limit_install
     description = "Calico: install CNI plugin"
 
     def as_new_mesos_task(self, agent_id):
         task = self.new_default_task(agent_id)
-        calico_conf = '{"name": "calico", "type": "calico", "ipam": { "type": "calico-ipam"}}'
-
-        commands = ["mkdir -p %s" % config.cni_plugins_dir,
-                    "cp -f ./calico %s/calico" % config.cni_plugins_dir,
-                    "cp -f ./calico %s/calico-ipam" % config.cni_plugins_dir,
-                    "echo '%s' | tee %s/calico.conf" % (calico_conf, config.cni_config_dir)]
-
-        task.command.value = ' && '.join(commands)
         task.command.user = "root"
+        task.command.value = "./installer cni %s %s" % (config.cni_plugins_dir, config.cni_config_dir)
+        if self.role == "slave_public":
+            task.command.value += " --public"
 
         # Download the Calico CNI Binary
         uri = task.command.uris.add()
@@ -291,6 +286,19 @@ class TaskInstallCalicoCNI(Task):
         uri.executable = True
         uri.cache = True
         uri.extract = False
+
+        # Download Calico CNI IPAM Binary
+        uri = task.command.uris.add()
+        uri.value = config.calico_cni_ipam_binary_url
+        uri.executable = True
+        uri.cache = True
+        uri.extract = False
+
+        # Download the installer binary
+        uri = task.command.uris.add()
+        uri.value = config.installer_url
+        uri.executable = True
+        uri.cache = USE_CACHED_INSTALLER
 
         return task
 

--- a/universe/config.json
+++ b/universe/config.json
@@ -3,16 +3,6 @@
     "calico": {
       "description": "Calico specific configuration properties.",
       "properties": {
-        "override-node-image": {
-          "type": "string",
-          "description": "Override the node image specified in resources.json",
-          "default": ""
-        },
-        "override-installer-url": {
-          "type": "string",
-          "description": "Override the URL for the installer binary.",
-          "default": ""
-        },
         "framework-name": {
           "type": "string",
           "description": "The name of the framework.",
@@ -157,6 +147,23 @@
         "cni-config-dir"
       ],
       "type": "object"
+    },
+    "resource-overrides": {
+      "description": "Override resources. Note: If your cluster does not have WAN and you are pre-fetching resources.json, Calico will be unable to download these files.",
+      "properties": {
+        "node-image": {
+          "type": "string",
+          "description": "Override the node image specified in resources.json"
+        },
+        "installer-url": {
+          "type": "string",
+          "description": "Override the URL for the installer binary."
+        },
+        "framework-image": {
+          "type": "string",
+          "description": "Override the docker image for the calico-dcos framework."
+        }
+      }
     }
   },
   "required": [

--- a/universe/config.json
+++ b/universe/config.json
@@ -131,12 +131,12 @@
           "type": "string"
         },
         "cni-plugins-dir": {
-          "default": "/opt/mesos/cni/bin/",
+          "default": "/opt/mesosphere/active/cni/",
           "description": "Location of CNI plugins on the Agent.",
           "type": "string"
         },
         "cni-config-dir": {
-          "default": "/opt/mesos/cni/conf/",
+          "default": "/opt/mesosphere/etc/dcos/network/cni/",
           "description": "Location of CNI configs.",
           "type": "string"
         }

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -4,9 +4,18 @@
     "type": "DOCKER",
     "network": "HOST",
     "docker": {
-      "image": "{{resource.assets.container.docker.calico-dcos}}",
       "network": "HOST",
-      "forcePullImage": true
+      "forcePullImage": true,
+      "image":
+        {{! If resource-overrides.framework-image is set, use it as the framework image. }}
+        {{#resource-overrides.framework-image}}
+          "{{resource-overrides.framework-image}}"
+        {{/resource-overrides.framework-image}}
+
+        {{! If its not set, default to the one in resources.json }}
+        {{^resource-overrides.framework-image}}
+          "{{resource.assets.container.docker.calico-dcos}}"
+        {{/resource-overrides.framework-image}}
     }
   },
   "args": [],
@@ -15,7 +24,26 @@
   "instances": 1,
   "env": {
     "CALICO_CALICOCTL_URL": "{{resource.assets.uris.calicoctl}}",
-    "CALICO_NODE_IMG": {{#calico.override-node-image?}}"{{calico.override-node-image}}"{{/calico.override-node-image}}{{^calico.override-node-image?}}"{{resource.assets.container.docker.calico-node}}"{{/calico.override-node-image}},
+    "CALICO_NODE_IMG":
+    {{! If resource-overrides.node-image is set, use it as the node-image. }}
+    {{#resource-overrides.node-image}}
+      "{{resource-overrides.node-image}}",
+    {{/resource-overrides.node-image}}
+    {{! Otherwise, default to the node-image in resources.json }}
+    {{^resource-overrides.node-image}}
+      "{{resource.assets.container.docker.calico-node}}",
+    {{/resource-overrides.node-image}}
+
+    "CALICO_INSTALLER_URL":
+      {{! If resource-overrides.installer-url is set, use it as the installer url. }}
+      {{#resource-overrides.installer-url}}
+        "{{resource-overrides.installer-url}}",
+      {{/resource-overrides.installer-url}}
+      {{! Otherwise, default to the one in resources.json }}
+      {{^resource-overrides.installer-url}}
+        "{{resource.assets.uris.calico-installer}}",
+      {{/resource-overrides.installer-url}}
+
     "CALICO_LIBNETWORK_IMG": "{{resource.assets.container.docker.calico-libnetwork}}",
     {{#calico.allow-docker-update}}"CALICO_ALLOW_DOCKER_UPDATE": "true",{{/calico.allow-docker-update}}
     "CALICO_MAX_CONCURRENT_RESTARTS": "{{calico.max-concurrent-restarts}}",
@@ -29,7 +57,6 @@
     "CALICO_CPU_LIMIT_LIBNETWORK": "{{calico.cpu-limit-libnetwork}}",
     "CALICO_MEM_LIMIT_LIBNETWORK": "{{calico.mem-limit-libnetwork}}",
     "CALICO_STATUS_DNS": "{{calico.status-dns}}",
-    "CALICO_INSTALLER_URL": {{#calico.override-installer-url?}}"{{calico.override-installer-url}}"{{/calico.override-installer-url}}{{^calico.override-installer-url}}"{{resource.assets.uris.calico-installer}}"{{/calico.override-installer-url}},
     "ETCD_SRV": "{{etcd.etcd-discovery-url}}",
     "ETCD_BINARY_URL": "{{resource.assets.uris.etcd}}",
     "MESOS_MASTER": "{{mesos.master}}",

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -23,7 +23,6 @@
   "mem": {{calico.mem-limit-framework}},
   "instances": 1,
   "env": {
-    "CALICO_CALICOCTL_URL": "{{resource.assets.uris.calicoctl}}",
     "CALICO_NODE_IMG":
     {{! If resource-overrides.node-image is set, use it as the node-image. }}
     {{#resource-overrides.node-image}}

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -62,7 +62,8 @@
     "MESOS_MASTER": "{{mesos.master}}",
     "MESOS_CNI_PLUGINS_DIR": "{{mesos.cni-plugins-dir}}",
     "MESOS_CNI_CONFIG_DIR": "{{mesos.cni-config-dir}}",
-    "CALICO_CNI_BINARY_URL": "{{resource.assets.uris.calico-cni}}"
+    "CALICO_CNI_BINARY_URL": "{{resource.assets.uris.calico-cni}}",
+    "CALICO_CNI_IPAM_BINARY_URL": "{{resource.assets.uris.calico-ipam}}"
   },
   "labels": {
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{calico.framework-name}}"

--- a/universe/resource.json
+++ b/universe/resource.json
@@ -7,14 +7,14 @@
   "assets": {
     "container": {
       "docker": {
-        "calico-dcos": "djosborne/calico-dcos:v0.2.0",
+        "calico-dcos": "calico/calico-dcos:v0.2.0",
         "calico-node": "calico/node:v0.20.0",
         "calico-libnetwork": "calico/node-libnetwork:v0.8.0"
       }
     },
     "uris": {
       "etcd": "https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz",
-      "calicoctl": "https://github.com/projectcalico/calico-containers/releases/download/v0.20.0/calicoctl",
+      "calicoctl": "https://github.com/projectcalico/calico-containers/releases/download/v0.21.0/calicoctl",
       "calico-cni": "https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico",
       "calico-installer": "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.5/installer"
     }

--- a/universe/resource.json
+++ b/universe/resource.json
@@ -16,6 +16,7 @@
       "etcd": "https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz",
       "calicoctl": "https://github.com/projectcalico/calico-containers/releases/download/v0.21.0/calicoctl",
       "calico-cni": "https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico",
+      "calico-ipam": "https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico-ipam",
       "calico-installer": "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.5/installer"
     }
   }

--- a/universe/resource.json
+++ b/universe/resource.json
@@ -14,7 +14,6 @@
     },
     "uris": {
       "etcd": "https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz",
-      "calicoctl": "https://github.com/projectcalico/calico-containers/releases/download/v0.21.0/calicoctl",
       "calico-cni": "https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico",
       "calico-ipam": "https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico-ipam",
       "calico-installer": "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.5/installer"


### PR DESCRIPTION
Updates for Calico-DC/OS CNI.

Commits are factored to be fixes for each of the following:
- converted the CNI install task into an installer task so it can restart the Agent process (which, as it turns out, is necessary), fixing #20 .
- Run calico-node by using `docker run` directly, so we can pass in the RPF_FILTER variable to felix. (fixing #28 and also #25) 
- Fixed and moved paramaterized overrides into debug section of install.