### PR TITLE
Fixes and Improvements for Calico-DC/OS v3

### DIFF
--- a/framework/config.py
+++ b/framework/config.py
@@ -21,16 +21,27 @@ _log = logging.getLogger(__name__)
 
 
 class Config(object):
+    """
+    Config options for the cluster.
+
+    Note: construction of this object happens in _main_ of this file, on import.
+    Logging is not yet initialized, so print on errors.
+    """
     def __init__(self):
         self._missing = []
         self.node_img = self.getenv("CALICO_NODE_IMG")
         self.libnetwork_img = self.getenv("CALICO_LIBNETWORK_IMG")
-        self.allow_docker_update = bool(self.getenv("CALICO_ALLOW_DOCKER_UPDATE", can_omit=True))
-        self.allow_agent_update = bool(self.getenv("CALICO_ALLOW_AGENT_UPDATE", can_omit=True))
+        self.allow_docker_update = self.getenv("CALICO_ALLOW_DOCKER_UPDATE", can_omit=True) != "false"
+        self.enable_install_cni= self.getenv("CALICO_ENABLE_INSTALL_CNI", can_omit=True) != "false"
+        self.enable_run_node = self.getenv("CALICO_ENABLE_RUN_NODE", can_omit=True) != "false"
+        self.enable_run_libnetwork = self.getenv("CALICO_ENABLE_RUN_LIBNETWORK", can_omit=True) != "false"
+        self.enable_run_etcd_proxy = self.getenv("CALICO_ENABLE_RUN_ETCD_PROXY", can_omit=True) != "false"
         self.max_concurrent_restarts = int(self.getenv("CALICO_MAX_CONCURRENT_RESTARTS"))
         self.zk_persist_url = self.getenv("CALICO_ZK")
-        self.cpu_limit_install = float(self.getenv("CALICO_CPU_LIMIT_INSTALL"))
-        self.mem_limit_install = int(self.getenv("CALICO_MEM_LIMIT_INSTALL"))
+        self.cpu_limit_install_docker = float(self.getenv("CALICO_CPU_LIMIT_INSTALL_DOCKER"))
+        self.mem_limit_install_docker = int(self.getenv("CALICO_MEM_LIMIT_INSTALL_DOCKER"))
+        self.cpu_limit_install_cni = float(self.getenv("CALICO_CPU_LIMIT_INSTALL_CNI"))
+        self.mem_limit_install_cni = int(self.getenv("CALICO_MEM_LIMIT_INSTALL_CNI"))
         self.cpu_limit_etcd_proxy = float(self.getenv("CALICO_CPU_LIMIT_ETCD_PROXY"))
         self.mem_limit_etcd_proxy = int(self.getenv("CALICO_MEM_LIMIT_ETCD_PROXY"))
         self.cpu_limit_node = float(self.getenv("CALICO_CPU_LIMIT_NODE"))
@@ -44,6 +55,8 @@ class Config(object):
 
         self.etcd_binary_url = self.getenv("ETCD_BINARY_URL")
         self.etcd_discovery = self.getenv("ETCD_SRV")
+        self.docker_cluster_store = self.getenv("DOCKER_CLUSTER_STORE", can_omit=True)
+        self.etcd_endpoints = self.getenv("ETCD_ENDPOINTS")
 
         self.mesos_master = self.getenv("MESOS_MASTER")
         self.cni_plugins_dir = self.getenv("MESOS_CNI_PLUGINS_DIR")
@@ -57,6 +70,26 @@ class Config(object):
         # zk://<host1:port1>,<host2:port2>.../directory/to/story/config
         assert self.zk_persist_url.startswith("zk://")
         self.zk_hosts, self.zk_persist_dir = self.zk_persist_url[5:].split("/", 1)
+
+        if not self.docker_cluster_store:
+            """
+            If user hasn't specified a cluster_store, convert the ETCD_ENDPOINTS into a valid docker cluster store.
+            example:
+
+            'http://m1.dcos:2379,http://m2.dcos:2379,http://m3.dcos:2379'
+            to
+            'etcd://m1.dcos:2379,m2.dcos:2379,m3.dcos:2379'
+            """
+            self.docker_cluster_store = "etcd://"
+            cluster_store_without_uri = []
+            for endpoint in self.etcd_endpoints.split(","):
+                if endpoint[:7] != "http://":
+                    _log.error("Calico Installation Framework currently only supports http. "
+                               "If you'd like to use https, please manually install Calico in DC/OS.")
+                    sys.exit(1)
+                cluster_store_without_uri.append(endpoint[7:])
+            self.docker_cluster_store += ",".join(cluster_store_without_uri)
+            print "No cluster store provided. Using: %s" % self.docker_cluster_store
 
         # Construct the web status URL
         self.webserver_url = "http://%s:%s/" % (self.webserver_dns,

--- a/universe/config.json
+++ b/universe/config.json
@@ -1,17 +1,17 @@
 {
   "properties": {
-    "calico": {
-      "description": "Calico specific configuration properties.",
+    "Framework Settings": {
+      "description": "Configuration options for Calico's DC/OS Framework.",
       "properties": {
         "framework-name": {
           "type": "string",
           "description": "The name of the framework.",
-          "default": "calico"
+          "default": "calico-install-framework"
         },
-        "allow-docker-update": {
-          "type": "boolean",
-          "description": "Whether the Calico framework is allowed to reconfigure and restart Docker on the Mesos Agent to install Docker with multi-host networking.  Note that during restart, the agent will not be available, and tasks running on the agent will be lost.",
-          "default": true
+        "master": {
+          "default": "zk://master.mesos:2181/mesos",
+          "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
+          "type": "string"
         },
         "max-concurrent-restarts": {
           "type": "integer",
@@ -23,63 +23,15 @@
           "description": "The URL of Zookeeper to be used to persist Calico framework data. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/calico, including the trailing path.",
           "type": "string"
         },
-        "cpu-limit-framework": {
+        "cpu-limit": {
           "default": 0.2,
           "description": "The CPU shares for the Calico framework.",
           "minimum": 0.01,
           "type": "number"
         },
-        "mem-limit-framework": {
+        "mem-limit": {
           "default": 512,
           "description": "Memory limit (MB) for the Calico framework.",
-          "minimum": 32,
-          "type": "integer"
-        },
-        "cpu-limit-install": {
-          "default": 0.2,
-          "description": "The CPU shares for each install task instance.",
-          "minimum": 0.01,
-          "type": "number"
-        },
-        "mem-limit-install": {
-          "default": 512,
-          "description": "Memory limit (MB) for each install task instance.",
-          "minimum": 32,
-          "type": "integer"
-        },
-        "cpu-limit-etcd-proxy": {
-          "default": 0.1,
-          "description": "The CPU shares for each etcd proxy instance.",
-          "minimum": 0.01,
-          "type": "number"
-        },
-        "mem-limit-etcd-proxy": {
-          "default": 128,
-          "description": "Memory limit (MB) for each etcd proxy instance.",
-          "minimum": 32,
-          "type": "integer"
-        },
-        "cpu-limit-node": {
-          "default": 0.2,
-          "description": "The CPU shares for each Calico node instance.",
-          "minimum": 0.01,
-          "type": "number"
-        },
-        "mem-limit-node": {
-          "default": 256,
-          "description": "Memory limit (MB) for each Calico node instance.",
-          "minimum": 32,
-          "type": "integer"
-        },
-        "cpu-limit-libnetwork": {
-          "default": 0.2,
-          "description": "The CPU shares for each Calico Docker Network driver instance.",
-          "minimum": 0.01,
-          "type": "number"
-        },
-        "mem-limit-libnetwork": {
-          "default": 256,
-          "description": "Memory limit (MB) for each Calico Docker Network driver instance.",
           "minimum": 32,
           "type": "integer"
         },
@@ -87,48 +39,107 @@
           "default": "calico.marathon.mesos",
           "description": "The DNS name used to resolve the Calico status web page.",
           "type": "string"
+        },
+        "override-framework-image": {
+          "type": "string",
+          "description": "Override the docker image for the calico-dcos framework."
+        },
+        "override-installer-url": {
+          "type": "string",
+          "description": "Override the URL for the installer binary."
         }
       },
       "required": [
         "framework-name",
-        "allow-docker-update",
+        "master",
         "max-concurrent-restarts",
         "zk",
-        "cpu-limit-framework",
-        "mem-limit-framework",
-        "cpu-limit-install",
-        "mem-limit-install",
-        "cpu-limit-etcd-proxy",
-        "mem-limit-etcd-proxy",
-        "cpu-limit-node",
-        "mem-limit-node",
-        "cpu-limit-libnetwork",
-        "mem-limit-libnetwork",
+        "cpu-limit",
+        "mem-limit",
         "status-dns"
       ],
       "type": "object"
     },
-    "etcd": {
-      "description": "etcd specific configuration properties",
+    "Etcd Settings": {
+      "description": "Configure etcd settings used by calico/node, calico/libnetwork-plugin, and calico-CNI. Below presents the option of whether to run etcd on each agent in proxy mode, forwarding requests made to localhost:2379 to the etcd clutser avaiable via the etcd-discovery-url presented by the Universe etcd package. Users who prefer to run etcd themselves on an agent can disable etcd proxy, and modify etcd-endpoints to point at their own etcd server directly.\n\nWARNING: The docker cluster-store configuration by default will use etcd-proxy. Ensure if you have disabled etcd-proxy, that you configure docker to use a different datastore as well.",
+      "type": "object",
       "properties": {
+        "run-proxy": {
+          "type": "boolean",
+          "description": "Enable running etcd-proxy on each agent. Keep enabled if using Universe etcd package.",
+          "default": true
+        },
         "etcd-discovery-url": {
           "default": "etcd.mesos",
-          "description": "The etcd service discovery URL used to determine the addresses of the full etcd cluster.",
+          "description": "The etcd service discovery URL which via an SRV lookup resolves to the Universe etcd package. Used by etcd-proxy to forward etcd requests made on localhost:2379 to the universe etcd package.",
           "type": "string"
+        },
+        "etcd-endpoints": {
+          "description": "The address used by Calico to connect to etcd. If etcd-proxy is enabled, keep as 'http://localhost:2379'. Otherwise, enter url of etcd server.",
+          "type": "string",
+          "default": "http://localhost:2379"
+        },
+        "cpu-limit": {
+          "default": 0.1,
+          "description": "The CPU shares for each etcd proxy instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit": {
+          "default": 128,
+          "description": "Memory limit (MB) for each etcd proxy instance.",
+          "minimum": 32,
+          "type": "integer"
         }
       },
       "required": [
-        "etcd-discovery-url"
-      ],
-      "type": "object"
+        "run-proxy",
+        "etcd-discovery-url",
+        "etcd-endpoints",
+        "cpu-limit",
+        "mem-limit"
+      ]
     },
-    "mesos": {
-      "description": "Mesos specific configuration properties",
+    "Configure Docker Cluster-Store": {
+      "description": "Reconfigure Docker with a cluster-store. Only required if using Calico's Docker plugin.",
+      "type": "object",
       "properties": {
-        "master": {
-          "default": "zk://master.mesos:2181/mesos",
-          "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
+        "enable": {
+          "type": "boolean",
+          "description": "Whether the Calico framework is allowed to reconfigure and restart Docker on the Mesos Agent to install Docker with multi-host networking.  Note that during restart, the agent will not be available, and tasks running on the agent will be lost.",
+          "default": true
+        },
+        "override-docker-cluster-store": {
+          "description": "URL of the distributed storage backend for Docker. When ommitted, this will be constructed from etcd-endpoints.",
           "type": "string"
+        },
+        "cpu-limit": {
+          "description": "The CPU shares for each Calico node instance.",
+          "type": "number",
+          "default": 0.2,
+          "minimum": 0.01
+        },
+        "mem-limit": {
+          "description": "Memory limit (MB) for each Calico node instance.",
+          "type": "integer",
+          "default": 256,
+          "minimum": 32
+        }
+      },
+      "required": [
+        "enable",
+        "cpu-limit",
+        "mem-limit"
+      ]
+    },
+    "Install CNI": {
+      "description": "Installs Calico's CNI plugin and a default CNI network configuration on all agents, then restarts each agent (to pickup the new configuration).",
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "description": "Enable installation of CNI plugin and network.",
+          "default": true
         },
         "cni-plugins-dir": {
           "default": "/opt/mesosphere/active/cni/",
@@ -139,37 +150,96 @@
           "default": "/opt/mesosphere/etc/dcos/network/cni/",
           "description": "Location of CNI configs.",
           "type": "string"
+        },
+        "cpu-limit": {
+          "default": 0.2,
+          "description": "The CPU shares for each install task instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit": {
+          "default": 512,
+          "description": "Memory limit (MB) for each install task instance.",
+          "minimum": 32,
+          "type": "integer"
         }
       },
       "required": [
-        "master",
+        "enable",
         "cni-plugins-dir",
-        "cni-config-dir"
-      ],
-      "type": "object"
+        "cni-config-dir",
+        "cpu-limit",
+        "mem-limit"
+      ]
     },
-    "resource-overrides": {
-      "description": "Override resources. Note: If your cluster does not have WAN and you are pre-fetching resources.json, Calico will be unable to download these files.",
+    "Run Calico-Node": {
+      "description": "Run the calico/node docker container on all agents. Required if using either Calico's CNI or Docker plugin.",
+      "type": "object",
       "properties": {
-        "node-image": {
-          "type": "string",
-          "description": "Override the node image specified in resources.json"
+        "enable": {
+          "description": "Enable running calico/node on each agent.",
+          "type": "boolean",
+          "default": true
         },
-        "installer-url": {
-          "type": "string",
-          "description": "Override the URL for the installer binary."
+        "cpu-limit": {
+          "description": "The CPU shares for each Calico node instance.",
+          "type": "number",
+          "default": 0.2,
+          "minimum": 0.01
         },
-        "framework-image": {
-          "type": "string",
-          "description": "Override the docker image for the calico-dcos framework."
+        "mem-limit": {
+          "description": "Memory limit (MB) for each Calico node instance.",
+          "type": "integer",
+          "default": 256,
+          "minimum": 32
+        },
+        "override-node-image": {
+          "description": "Override the node image specified in resources.json",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "enable",
+        "cpu-limit",
+        "mem-limit"
+      ]
+    },
+    "Run Calico-Libnetwork": {
+      "description": "Run calico/libnetwork on all agents. Required to use calico networking for Docker containers.",
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "description": "Enable running calico/libnetwork on each agent.",
+          "default": true
+        },
+        "cpu-limit": {
+          "default": 0.2,
+          "description": "The CPU shares for each Calico Docker Network driver instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit": {
+          "default": 256,
+          "description": "Memory limit (MB) for each Calico Docker Network driver instance.",
+          "minimum": 32,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enable",
+        "cpu-limit",
+        "mem-limit"
+      ]
     }
   },
   "required": [
-    "calico",
-    "etcd",
-    "mesos"
+    "Framework Settings",
+    "Etcd Settings",
+    "Configure Docker Cluster-Store",
+    "Install CNI",
+    "Run Calico-Node",
+    "Run Calico-Libnetwork"
   ],
   "type": "object"
 }

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -1,71 +1,84 @@
 {
-  "id": "{{calico.framework-name}}",
+  "id": "{{Framework Settings.framework-name}}",
   "container": {
     "type": "DOCKER",
-    "network": "HOST",
     "docker": {
       "network": "HOST",
       "forcePullImage": true,
       "image":
-        {{! If resource-overrides.framework-image is set, use it as the framework image. }}
-        {{#resource-overrides.framework-image}}
-          "{{resource-overrides.framework-image}}"
-        {{/resource-overrides.framework-image}}
+        {{! If Framework Settings.override-framework-image is set, use it as the framework image. }}
+        {{#Framework Settings.override-framework-image}}
+          "{{Framework Settings.override-framework-image}}"
+        {{/Framework Settings.override-framework-image}}
 
         {{! If its not set, default to the one in resources.json }}
-        {{^resource-overrides.framework-image}}
+        {{^Framework Settings.override-framework-image}}
           "{{resource.assets.container.docker.calico-dcos}}"
-        {{/resource-overrides.framework-image}}
+        {{/Framework Settings.override-framework-image}}
     }
   },
   "args": [],
-  "cpus": {{calico.cpu-limit-framework}},
-  "mem": {{calico.mem-limit-framework}},
+  "cpus": {{Framework Settings.cpu-limit}},
+  "mem": {{Framework Settings.mem-limit}},
   "instances": 1,
   "env": {
+    "CALICO_INSTALLER_URL":
+      {{! If Framework Settings.override-installer-url is set, use it as the installer url. }}
+      {{#Framework Settings.override-installer-url}}
+        "{{Framework Settings.override-installer-url}}",
+      {{/Framework Settings.override-installer-url}}
+      {{! Otherwise, default to the one in resources.json }}
+      {{^Framework Settings.override-installer-url}}
+        "{{resource.assets.uris.calico-installer}}",
+      {{/Framework Settings.override-installer-url}}
+
+    "MESOS_MASTER": "{{Framework Settings.master}}",
+    "CALICO_MAX_CONCURRENT_RESTARTS": "{{Framework Settings.max-concurrent-restarts}}",
+    "CALICO_ZK": "{{Framework Settings.zk}}",
+    "CALICO_STATUS_DNS": "{{Framework Settings.status-dns}}",
+
+    "CALICO_ALLOW_DOCKER_UPDATE": "{{Configure Docker Cluster-Store.enable}}",
+    "CALICO_CPU_LIMIT_INSTALL_DOCKER": "{{Configure Docker Cluster-Store.cpu-limit}}",
+    "CALICO_MEM_LIMIT_INSTALL_DOCKER": "{{Configure Docker Cluster-Store.mem-limit}}",
+    "DOCKER_CLUSTER_STORE": "{{Configure Docker Cluster-Store.override-docker-cluster-store}}",
+
+    "CALICO_ENABLE_RUN_ETCD_PROXY": "{{Etcd Settings.run-proxy}}",
+    "ETCD_SRV": "{{Etcd Settings.etcd-discovery-url}}",
+    "CALICO_CPU_LIMIT_ETCD_PROXY": "{{Etcd Settings.cpu-limit}}",
+    "CALICO_MEM_LIMIT_ETCD_PROXY": "{{Etcd Settings.mem-limit}}",
+    "ETCD_BINARY_URL": "{{resource.assets.uris.etcd}}",
+
+
+    "CALICO_ENABLE_INSTALL_CNI": "{{Install CNI.enable}}",
+    "MESOS_CNI_PLUGINS_DIR": "{{Install CNI.cni-plugins-dir}}",
+    "MESOS_CNI_CONFIG_DIR": "{{Install CNI.cni-config-dir}}",
+    "CALICO_CPU_LIMIT_INSTALL_CNI": "{{Install CNI.cpu-limit}}",
+    "CALICO_MEM_LIMIT_INSTALL_CNI": "{{Install CNI.mem-limit}}",
+    "CALICO_CNI_BINARY_URL": "{{resource.assets.uris.calico-cni}}",
+    "CALICO_CNI_IPAM_BINARY_URL": "{{resource.assets.uris.calico-ipam}}",
+
+
+    "CALICO_ENABLE_RUN_NODE": "{{Run Calico-Node.enable}}",
+    "ETCD_ENDPOINTS": "{{Etcd Settings.etcd-endpoints}}",
+    "CALICO_CPU_LIMIT_NODE": "{{Run Calico-Node.cpu-limit}}",
+    "CALICO_MEM_LIMIT_NODE": "{{Run Calico-Node.mem-limit}}",
     "CALICO_NODE_IMG":
     {{! If resource-overrides.node-image is set, use it as the node-image. }}
-    {{#resource-overrides.node-image}}
-      "{{resource-overrides.node-image}}",
-    {{/resource-overrides.node-image}}
+    {{#Run Calico-Node.override-node-image}}
+      "{{Run Calico-Node.override-node-image}}",
+    {{/Run Calico-Node.override-node-image}}
     {{! Otherwise, default to the node-image in resources.json }}
-    {{^resource-overrides.node-image}}
+    {{^Run Calico-Node.override-node-image}}
       "{{resource.assets.container.docker.calico-node}}",
-    {{/resource-overrides.node-image}}
+    {{/Run Calico-Node.override-node-image}}
 
-    "CALICO_INSTALLER_URL":
-      {{! If resource-overrides.installer-url is set, use it as the installer url. }}
-      {{#resource-overrides.installer-url}}
-        "{{resource-overrides.installer-url}}",
-      {{/resource-overrides.installer-url}}
-      {{! Otherwise, default to the one in resources.json }}
-      {{^resource-overrides.installer-url}}
-        "{{resource.assets.uris.calico-installer}}",
-      {{/resource-overrides.installer-url}}
-
-    "CALICO_LIBNETWORK_IMG": "{{resource.assets.container.docker.calico-libnetwork}}",
-    {{#calico.allow-docker-update}}"CALICO_ALLOW_DOCKER_UPDATE": "true",{{/calico.allow-docker-update}}
-    "CALICO_MAX_CONCURRENT_RESTARTS": "{{calico.max-concurrent-restarts}}",
-    "CALICO_ZK": "{{calico.zk}}",
-    "CALICO_CPU_LIMIT_INSTALL": "{{calico.cpu-limit-install}}",
-    "CALICO_MEM_LIMIT_INSTALL": "{{calico.mem-limit-install}}",
-    "CALICO_CPU_LIMIT_ETCD_PROXY": "{{calico.cpu-limit-etcd-proxy}}",
-    "CALICO_MEM_LIMIT_ETCD_PROXY": "{{calico.mem-limit-etcd-proxy}}",
-    "CALICO_CPU_LIMIT_NODE": "{{calico.cpu-limit-node}}",
-    "CALICO_MEM_LIMIT_NODE": "{{calico.mem-limit-node}}",
-    "CALICO_CPU_LIMIT_LIBNETWORK": "{{calico.cpu-limit-libnetwork}}",
-    "CALICO_MEM_LIMIT_LIBNETWORK": "{{calico.mem-limit-libnetwork}}",
-    "CALICO_STATUS_DNS": "{{calico.status-dns}}",
-    "ETCD_SRV": "{{etcd.etcd-discovery-url}}",
-    "ETCD_BINARY_URL": "{{resource.assets.uris.etcd}}",
-    "MESOS_MASTER": "{{mesos.master}}",
-    "MESOS_CNI_PLUGINS_DIR": "{{mesos.cni-plugins-dir}}",
-    "MESOS_CNI_CONFIG_DIR": "{{mesos.cni-config-dir}}",
-    "CALICO_CNI_BINARY_URL": "{{resource.assets.uris.calico-cni}}",
-    "CALICO_CNI_IPAM_BINARY_URL": "{{resource.assets.uris.calico-ipam}}"
+    "CALICO_ENABLE_RUN_LIBNETWORK": "{{Run Calico-Libnetwork.enable}}",
+    "CALICO_CPU_LIMIT_LIBNETWORK": "{{Run Calico-Libnetwork.cpu-limit}}",
+    "CALICO_MEM_LIMIT_LIBNETWORK": "{{Run Calico-Libnetwork.mem-limit}}",
+    "CALICO_LIBNETWORK_IMG": "{{resource.assets.container.docker.calico-libnetwork}}"
   },
   "labels": {
-    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{calico.framework-name}}"
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{Framework Settings.framework-name}}"
   },
   "requirePorts":true,
   "ports": [

--- a/universe/package.json
+++ b/universe/package.json
@@ -1,13 +1,13 @@
 {
   "packagingVersion": "3.0",
   "name": "calico",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "tags": ["calico", "networking", "ip-per-container", "ip-per-task", "policy"],
-  "description": "Calico networking for DCOS.  Calico provides IP-per-task functionality with rich policy.  This framework optionally installs Docker multi-host networking (required for Calico with the Docker containerizer) and Agent network hooks with netmodules (required for Calico with Unified tasks).  Both installations will cause temporary restarts of an Agent causing transient task loss.  The number of agents restarted at the same time is configurable and defaults to a single concurrent restart.  At the moment, only a limited set of DCOS versions and OSes are supported - check the documentation for details.  The framework will still run on unsupported versions, in which case the Agent network hooks will not be installed and Calico networking will only be available with the Docker containerizer.",
+  "description": "Calico networking for DC/OS.  Calico provides IP-per-task functionality with rich policy.  This framework optionally installs Docker multi-host networking (required for Calico with the Docker containerizer) and Agent network hooks with netmodules (required for Calico with Unified tasks).  Both installations will cause temporary restarts of an Agent causing transient task loss.  The number of agents restarted at the same time is configurable and defaults to a single concurrent restart.  At the moment, only a limited set of DC/OS versions and OSes are supported - check the documentation for details.  The framework will still run on unsupported versions, in which case the Agent network hooks will not be installed and Calico networking will only be available with the Docker containerizer.",
   "scm": "https://github.com/projectcalico/calico-containers.git",
   "website": "https://projectcalico.org",
-  "preInstallNotes": "Before installing Calico, ensure the DCOS etcd package is installed. Note: this scheduler makes permament changes to all Agents in the cluster. Calico Networking for DCOS is currently in alpha.",
-  "postInstallNotes": "Calico services are now running on your cluster. Follow the Calico DCOS guide available at https://github.com/projectcalico/calico-containers/blob/master/docs/mesos/DCOS.md",
+  "preInstallNotes": "Before installing Calico, ensure the DC/OS etcd package is installed. Note: this scheduler makes permament changes to all Agents in the cluster. Calico Networking for DC/OS is currently in alpha.",
+  "postInstallNotes": "Calico services are now running on your cluster. Follow the Calico DC/OS guide available at https://github.com/projectcalico/calico-containers/blob/master/docs/mesos/dcos.md",
   "maintainer": "rob@projectcalico.org",
   "licenses": [
     {

--- a/universe/resource.json
+++ b/universe/resource.json
@@ -14,8 +14,8 @@
     },
     "uris": {
       "etcd": "https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz",
-      "calico-cni": "https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico",
-      "calico-ipam": "https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico-ipam",
+      "calico-cni": "https://github.com/projectcalico/calico-cni/releases/download/v1.4.1/calico",
+      "calico-ipam": "https://github.com/projectcalico/calico-cni/releases/download/v1.4.1/calico-ipam",
       "calico-installer": "https://projectcalico.org/builds/installer"
     }
   }


### PR DESCRIPTION
- Refactored configuration settings to group by Major Task.
- Ripped out process checking/restarting, replaced with straight systemd
  calls. (restores functionality with v3)
- Made every task type disable-able.
- Added more config options for each task so its possible to hotswap out
  important pieces (such as using own etcd.)