### PR TITLE
Merge Libnetwork task into calico-node for v2.0 support

### DIFF
--- a/framework/config.py
+++ b/framework/config.py
@@ -30,11 +30,9 @@ class Config(object):
     def __init__(self):
         self._missing = []
         self.node_img = self.getenv("CALICO_NODE_IMG")
-        self.libnetwork_img = self.getenv("CALICO_LIBNETWORK_IMG")
         self.allow_docker_update = self.getenv("CALICO_ALLOW_DOCKER_UPDATE", can_omit=True) != "false"
         self.enable_install_cni= self.getenv("CALICO_ENABLE_INSTALL_CNI", can_omit=True) != "false"
         self.enable_run_node = self.getenv("CALICO_ENABLE_RUN_NODE", can_omit=True) != "false"
-        self.enable_run_libnetwork = self.getenv("CALICO_ENABLE_RUN_LIBNETWORK", can_omit=True) != "false"
         self.enable_run_etcd_proxy = self.getenv("CALICO_ENABLE_RUN_ETCD_PROXY", can_omit=True) != "false"
         self.max_concurrent_restarts = int(self.getenv("CALICO_MAX_CONCURRENT_RESTARTS"))
         self.zk_persist_url = self.getenv("CALICO_ZK")
@@ -46,8 +44,6 @@ class Config(object):
         self.mem_limit_etcd_proxy = int(self.getenv("CALICO_MEM_LIMIT_ETCD_PROXY"))
         self.cpu_limit_node = float(self.getenv("CALICO_CPU_LIMIT_NODE"))
         self.mem_limit_node = int(self.getenv("CALICO_MEM_LIMIT_NODE"))
-        self.cpu_limit_libnetwork = float(self.getenv("CALICO_CPU_LIMIT_LIBNETWORK"))
-        self.mem_limit_libnetwork = int(self.getenv("CALICO_MEM_LIMIT_LIBNETWORK"))
 
         self.installer_url = self.getenv("CALICO_INSTALLER_URL")
         self.calico_cni_binary_url = self.getenv("CALICO_CNI_BINARY_URL")

--- a/framework/framework.py
+++ b/framework/framework.py
@@ -99,7 +99,7 @@ class Agent(object):
            networking (this will restart Docker if necessary)
         -  Once Docker is updated, we can install net-modules and Calico plugin
            on the agent (this will restart the Agent if necessary)
-        -  Then Calico node and Calico libetwork driver can be started.
+        -  Then Calico node can be started.
 
         All failed tasks are rescheduled until:
         -  Non-persistent tasks finish successfully

--- a/framework/static/calico-status.html
+++ b/framework/static/calico-status.html
@@ -36,15 +36,12 @@ function refreshTable() {
 
 function buildNodeRow(nodeID, node) {
   nodeStatus = -1;
-  libnetworkStatus = -1;
   etcdProxyStatus = -1;
   cniInstallStatus = -1;
   dockerInstallStatus = -1;
 
   if ("TaskRunCalicoNode" in node)
     nodeStatus = node["TaskRunCalicoNode"]["state"]
-  if ("TaskRunCalicoLibnetwork" in node)
-    libnetworkStatus = node["TaskRunCalicoLibnetwork"]["state"]
   if ("TaskRunEtcdProxy" in node)
     etcdProxyStatus = node["TaskRunEtcdProxy"]["state"]
   if ("TaskInstallCalicoCNI" in node)
@@ -56,7 +53,6 @@ function buildNodeRow(nodeID, node) {
     "<tr id='" + nodeID + "'>" +
       "<td>" + nodeID + "</td>" +
       "<td>" + statusIdToString(nodeStatus) + "</td>" +
-      "<td>" + statusIdToString(libnetworkStatus) + "</td>" +
       "<td>" + statusIdToString(etcdProxyStatus) + "</td>" +
       "<td>" + statusIdToString(cniInstallStatus) + "</td>" +
       "<td>" + statusIdToString(dockerInstallStatus) + "</td>" +
@@ -111,7 +107,6 @@ $(document).ready(function() {
           <tr>
             <th>Agent</th>
             <th>Calico networking</th>
-            <th>Docker network driver</th>
             <th>Etcd Proxy</th>
             <th>CNI Install</th>
             <th>Docker Install</th>

--- a/universe/config.json
+++ b/universe/config.json
@@ -9,7 +9,7 @@
           "default": "calico-install-framework"
         },
         "master": {
-          "default": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4:2181,zk-5:2181/mesos",
+          "default": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos",
           "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
           "type": "string"
         },
@@ -19,7 +19,7 @@
           "default": 1
         },
         "zk": {
-          "default": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4:2181,zk-5:2181/calico",
+          "default": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/calico",
           "description": "The URL of Zookeeper to be used to persist Calico framework data. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/calico, including the trailing path.",
           "type": "string"
         },
@@ -61,7 +61,7 @@
       "type": "object"
     },
     "Etcd Settings": {
-      "description": "Configure etcd settings used by calico/node, calico/libnetwork-plugin, and calico-CNI. Below presents the option of whether to run etcd on each agent in proxy mode, forwarding requests made to localhost:2379 to the etcd clutser avaiable via the etcd-discovery-url presented by the Universe etcd package. Users who prefer to run etcd themselves on an agent can disable etcd proxy, and modify etcd-endpoints to point at their own etcd server directly.\n\nWARNING: The docker cluster-store configuration by default will use etcd-proxy. Ensure if you have disabled etcd-proxy, that you configure docker to use a different datastore as well.",
+      "description": "Configure etcd settings used by calico/node and calico-CNI. Below presents the option of whether to run etcd on each agent in proxy mode, forwarding requests made to localhost:2379 to the etcd clutser avaiable via the etcd-discovery-url presented by the Universe etcd package. Users who prefer to run etcd themselves on an agent can disable etcd proxy, and modify etcd-endpoints to point at their own etcd server directly.\n\nWARNING: The docker cluster-store configuration by default will use etcd-proxy. Ensure if you have disabled etcd-proxy, that you configure docker to use a different datastore as well.",
       "type": "object",
       "properties": {
         "run-proxy": {
@@ -203,34 +203,6 @@
         "cpu-limit",
         "mem-limit"
       ]
-    },
-    "Run Calico-Libnetwork": {
-      "description": "Run calico/libnetwork on all agents. Required to use calico networking for Docker containers.",
-      "type": "object",
-      "properties": {
-        "enable": {
-          "type": "boolean",
-          "description": "Enable running calico/libnetwork on each agent.",
-          "default": true
-        },
-        "cpu-limit": {
-          "default": 0.2,
-          "description": "The CPU shares for each Calico Docker Network driver instance.",
-          "minimum": 0.01,
-          "type": "number"
-        },
-        "mem-limit": {
-          "default": 256,
-          "description": "Memory limit (MB) for each Calico Docker Network driver instance.",
-          "minimum": 32,
-          "type": "integer"
-        }
-      },
-      "required": [
-        "enable",
-        "cpu-limit",
-        "mem-limit"
-      ]
     }
   },
   "required": [
@@ -238,8 +210,7 @@
     "Etcd Settings",
     "Configure Docker Cluster-Store",
     "Install CNI",
-    "Run Calico-Node",
-    "Run Calico-Libnetwork"
+    "Run Calico-Node"
   ],
   "type": "object"
 }

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -65,17 +65,12 @@
     "CALICO_NODE_IMG":
     {{! If resource-overrides.node-image is set, use it as the node-image. }}
     {{#Run Calico-Node.override-node-image}}
-      "{{Run Calico-Node.override-node-image}}",
+      "{{Run Calico-Node.override-node-image}}"
     {{/Run Calico-Node.override-node-image}}
     {{! Otherwise, default to the node-image in resources.json }}
     {{^Run Calico-Node.override-node-image}}
-      "{{resource.assets.container.docker.calico-node}}",
+      "{{resource.assets.container.docker.calico-node}}"
     {{/Run Calico-Node.override-node-image}}
-
-    "CALICO_ENABLE_RUN_LIBNETWORK": "{{Run Calico-Libnetwork.enable}}",
-    "CALICO_CPU_LIMIT_LIBNETWORK": "{{Run Calico-Libnetwork.cpu-limit}}",
-    "CALICO_MEM_LIMIT_LIBNETWORK": "{{Run Calico-Libnetwork.mem-limit}}",
-    "CALICO_LIBNETWORK_IMG": "{{resource.assets.container.docker.calico-libnetwork}}"
   },
   "labels": {
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{Framework Settings.framework-name}}"

--- a/universe/package.json
+++ b/universe/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "calico",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "tags": ["calico", "networking", "ip-per-container", "ip-per-task", "policy"],
   "description": "Calico networking for DC/OS.  Calico provides IP-per-task functionality with rich policy.  This Universe Package simplifies the installation of Calico and its dependencies on a stock DC/OS cluster. It is configurable such that it assumes Calico's dependencies are installed, and merely serves to ensure calico's core processes are running. By default, it configures Docker with multi-host networking (required to use Calico with the Docker Containerizer), and reboots each Agent to pick up Calico's CNI configuration (required for Calico with Unified tasks). Both of these steps will cause temporary restarts of an Agent causing transient task loss. A more stable approach to Calico in DC/OS will have users performing these steps manually, and disabling them in the Universe Package. At the moment, only a limited set of DC/OS versions and OSes are supported - check the documentation for details.  The framework will still run on unsupported versions, in which case the Agent network hooks will not be installed and Calico networking will only be available with the Docker containerizer.",
   "scm": "https://github.com/projectcalico/calico-containers.git",

--- a/universe/resource.json
+++ b/universe/resource.json
@@ -8,14 +8,13 @@
     "container": {
       "docker": {
         "calico-dcos": "calico/calico-dcos:latest",
-        "calico-node": "calico/node:latest",
-        "calico-libnetwork": "calico/node-libnetwork:latest"
+        "calico-node": "calico/node:v1.0.0-beta"
       }
     },
     "uris": {
       "etcd": "https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz",
-      "calico-cni": "https://github.com/projectcalico/calico-cni/releases/download/v1.4.1/calico",
-      "calico-ipam": "https://github.com/projectcalico/calico-cni/releases/download/v1.4.1/calico-ipam",
+      "calico-cni": "https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico",
+      "calico-ipam": "https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico-ipam",
       "calico-installer": "https://projectcalico.org/builds/installer"
     }
   }


### PR DESCRIPTION
Updates calico-dcos to v2.0 by removing libnetwork standalone task, moving relevant setup to calico-node task