### PR TITLE
Use https-based urls for Calico image resources

### DIFF
--- a/universe/resource.json
+++ b/universe/resource.json
@@ -1,8 +1,8 @@
 {
   "images": {
-    "icon-small": "http://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-48-48.png",
-    "icon-medium": "http://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-96-96.png",
-    "icon-large": "http://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-256-256.png"
+    "icon-small": "https://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-48-48.png",
+    "icon-medium": "https://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-96-96.png",
+    "icon-large": "https://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-256-256.png"
   },
   "assets": {
     "container": {


### PR DESCRIPTION
Currently, when using DC/OS via https with Calico deployed on it, Chrome gives the following warning on the Services page, causing the https indicator in the url to not turn green.

```
Mixed Content: The page at 'https://dcos.xxxxxxxx/#/services/' was loaded over HTTPS, but requested an insecure image 'http://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-48-48.png'. This content should also be served over HTTPS.
```

This PR changes the Calico image urls to use the https-based ones.